### PR TITLE
refactor: simplify device type mapping in editor-styles

### DIFF
--- a/src/utils/editor-styles.ts
+++ b/src/utils/editor-styles.ts
@@ -25,19 +25,18 @@ export const getFocalPointForDevice = (
 		return null;
 	}
 
+	// For desktop, use default focal point (no override)
+	if ( deviceType === 'Desktop' ) {
+		return null;
+	}
+
 	// Map WordPress editor device types to our device types
-	let targetDevice: 'mobile' | 'tablet' | null = null;
-	switch ( deviceType ) {
-		case 'Mobile':
-			targetDevice = 'mobile';
-			break;
-		case 'Tablet':
-			targetDevice = 'tablet';
-			break;
-		case 'Desktop':
-		default:
-			// For desktop, use default focal point (no override)
-			return null;
+	const targetDevice = deviceType === 'Mobile' || deviceType === 'Tablet' 
+		? deviceType.toLowerCase() as 'mobile' | 'tablet'
+		: null;
+
+	if ( ! targetDevice ) {
+		return null;
 	}
 
 	// Find matching responsive focal point


### PR DESCRIPTION
## Summary
- Replace verbose switch statement with concise conditional logic
- Explicitly handles only Mobile and Tablet device types
- Maintains type safety and future extensibility

## Changes
### Before
```typescript
let targetDevice: 'mobile' | 'tablet' | null = null;
switch ( deviceType ) {
    case 'Mobile':
        targetDevice = 'mobile';
        break;
    case 'Tablet':
        targetDevice = 'tablet';
        break;
    case 'Desktop':
    default:
        return null;
}
```

### After
```typescript
if ( deviceType === 'Desktop' ) {
    return null;
}

const targetDevice = deviceType === 'Mobile' || deviceType === 'Tablet' 
    ? deviceType.toLowerCase() as 'mobile' | 'tablet'
    : null;

if ( \! targetDevice ) {
    return null;
}
```

## Benefits
- **More readable**: Clear intent that only Mobile/Tablet are processed
- **Less code**: Reduced from 13 lines to 9 lines
- **Maintainable**: Easy to extend for future device types
- **Type safe**: Preserves TypeScript type safety

🤖 Generated with [Claude Code](https://claude.ai/code)